### PR TITLE
CIを効率化

### DIFF
--- a/.github/workflows/pull-request-test.yml
+++ b/.github/workflows/pull-request-test.yml
@@ -5,6 +5,10 @@ on:
     branches:
       - main
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   check:
     name: Test
@@ -18,22 +22,21 @@ jobs:
           node-version: 18
           cache: npm
 
-      - uses: actions/cache@v3
+      - name: Cache dependencies
+        uses: actions/cache@v3
+        id: node_modules_cache_id
         with:
           path: |
-            ~/.npm
-            ${{ github.workspace }}/.next/cache
-          key: ${{ runner.os }}-nextjs-${{ hashFiles('**/package-lock.json') }}-${{ hashFiles('**.[jt]s', '**.[jt]sx') }}
-          restore-keys: |
-            ${{ runner.os }}-nextjs-${{ hashFiles('**/package-lock.json') }}-
+            ${{ github.workspace }}/node_modules
+          key: node_modules-${{ runner.os }}-${{ hashFiles('**/package-lock.json') }}
 
       - name: Install dependencies
-        run: npm install
+        if: steps.node_modules_cache_id.outputs.cache-hit != 'true'
+        run: npm ci
 
       - name: Run code lint
         run: npm run lint
 
       - name: Run code tests
         run: npm run test
-
 

--- a/.github/workflows/storybook-pages.yml
+++ b/.github/workflows/storybook-pages.yml
@@ -26,22 +26,31 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-        
+
       - name: Setup Pages
         uses: actions/configure-pages@v3
-        
+
       - name: Use Node.js 18
         uses: actions/setup-node@v3
         with:
           node-version: 18
           cache: 'npm'
-          
+
+      - name: Cache dependencies
+        uses: actions/cache@v3
+        id: node_modules_cache_id
+        with:
+          path: |
+            ${{ github.workspace }}/node_modules
+          key: node_modules-${{ runner.os }}-${{ hashFiles('**/package-lock.json') }}
+
       - name: Install dependencies
+        if: steps.node_modules_cache_id.outputs.cache-hit != 'true'
         run: npm ci
-        
+
       - name: Build Storybook
         run: npm run build-storybook
-        
+
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v1
         with:


### PR DESCRIPTION
- `pull-request-test`にconcurrencyを追加
- node_modulesをキャッシュするように
- `npm install`を`npm ci`に置き換え