### PR TITLE
Pdfスライドコンポーネントの高さを修正

### DIFF
--- a/src/components/feature/wrapImage/WrapImage.tsx
+++ b/src/components/feature/wrapImage/WrapImage.tsx
@@ -2,6 +2,8 @@ import classNames from "classnames";
 import Image from "next/image";
 import { CSSProperties, FC } from "react";
 
+import { resizeToFitContainer } from "@/lib/resizeToFitContianer";
+
 export type CMSImage = {
   src: string;
   originalWidth: number;
@@ -79,12 +81,12 @@ export const WrapImage: FC<WrapImageProps> = ({
   }
 
   const { maxWidth, maxHeight } = rest;
-  const { width, height } = calcImgSize(
+  const { width, height } = resizeToFitContainer({
     maxWidth,
     maxHeight,
-    originalWidth,
-    originalHeight
-  );
+    width: originalWidth,
+    height: originalHeight,
+  });
   return (
     <Image
       className={rest.className}
@@ -94,30 +96,4 @@ export const WrapImage: FC<WrapImageProps> = ({
       height={height}
     />
   );
-};
-
-const calcImgSize = (
-  maxWidth: number,
-  maxHeight: number,
-  width: number,
-  height: number
-) => {
-  //縦が収まるように縮小したときの横幅
-  const widthByHeight = (maxHeight * width) / height;
-  //横が収まるように縮小したときの縦幅
-  const heightByWidth = (maxWidth * height) / width;
-
-  if (widthByHeight > maxWidth) {
-    //縦が収まるようにしたら横がはみ出た場合、横が収まるようにする
-    return {
-      width: maxWidth,
-      height: heightByWidth,
-    };
-  } else {
-    //縦が収まるようにしても横がはみ出なかった場合、その値を採用
-    return {
-      width: widthByHeight,
-      height: maxHeight,
-    };
-  }
 };

--- a/src/components/ui/pdfSlide/PdfSlide.tsx
+++ b/src/components/ui/pdfSlide/PdfSlide.tsx
@@ -144,7 +144,7 @@ export const PdfSlide: FC<PdfSlideProps> = ({ pdfUrl, width, height }) => {
 
           const { width: fitWidth } = resizeToFitContainer({
             maxWidth: settingSize(width),
-            maxHeight: settingSize(height),
+            maxHeight: settingSize(height) - 40, // 40はコントロールバーの高さ
             width: pdfPageSizes[index]?.originalWidth ?? 1,
             height: pdfPageSizes[index]?.originalHeight ?? 1,
           });


### PR DESCRIPTION
- propsで指定する高さ+40pxになっていたのを修正
- ついでにWrapImageでもresizeToFitContainerを使うよう修正