### PR TITLE
public下の画像の参照方法を変更

### DIFF
--- a/src/components/page/layout/Layout.tsx
+++ b/src/components/page/layout/Layout.tsx
@@ -6,6 +6,7 @@ import { PageFooter } from "@/components/ui/pageFooter";
 import { PageFooterLinkItem } from "@/components/ui/pageFooter/PageFooter";
 import { PageHeader } from "@/components/ui/pageHeader";
 import { PageHeaderLinkItem } from "@/components/ui/pageHeader/PageHeader";
+import { LogoImg } from "@/lib/publicImage";
 
 const headerItems = [
   {
@@ -83,7 +84,7 @@ export const Layout: FC<LayoutProps> = ({
         <PageHeader
           logo={
             <WrapImageSized
-              src={"./logo.png"}
+              src={LogoImg.src}
               alt={"Miyashita Lab"}
               priority
               width={152}

--- a/src/lib/publicImage.ts
+++ b/src/lib/publicImage.ts
@@ -1,0 +1,5 @@
+import CardDefaultImg from "public/card-default.png";
+import LogoImg from "public/logo.png";
+import MemberDefaultImg from "public/member-default.png";
+
+export { LogoImg, CardDefaultImg, MemberDefaultImg };


### PR DESCRIPTION
#76 で相対パスで画像を指定するようにしていたが、storybook環境でない場合相対パスは使えないのでダメだった。
storybookに関わらずpublic下の画像を参照する場合は、publicImage.tsを経由してimportで参照するようにした。