### PR TITLE
nextjsのscrollRestorationを有効にする

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -10,6 +10,9 @@ const nextConfig = {
       },
     ],
   },
+  experimental: {
+    scrollRestoration: true,
+  },
 };
 
 module.exports = nextConfig;


### PR DESCRIPTION
スクロール位置が復元されるようになる