### PR TITLE
Google ScholarにインデックスさせるためのMetaを追加

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -10,6 +10,14 @@ const nextConfig = {
       },
     ],
   },
+  rewrites: async () => {
+    return [
+      {
+        source: "/researches/:slug/assets/:name",
+        destination: "/api/asset-paper/:slug",
+      },
+    ];
+  },
   experimental: {
     scrollRestoration: true,
   },

--- a/src/components/feature/meta/Meta.tsx
+++ b/src/components/feature/meta/Meta.tsx
@@ -3,11 +3,9 @@ import { useRouter } from "next/router";
 import { FC } from "react";
 
 import { CMSImageWithSize } from "@/components/feature/wrapImage";
-import {
-  NEXT_PUBLIC_SITE_TITLE,
-  NEXT_PUBLIC_VERCEL_URL,
-} from "@/lib/publicEnvironments";
+import { NEXT_PUBLIC_SITE_TITLE } from "@/lib/publicEnvironments";
 import { CardDefaultImg } from "@/lib/publicImage";
+import { toPublicUrl } from "@/lib/routes";
 
 export type MetaProps = {
   pageTitle?: string;
@@ -40,10 +38,7 @@ export const Meta: FC<MetaProps> = ({
       <meta property={"og:image:url"} content={cardImage.src} />
       <meta property={"og:image:width"} content={String(cardImage.width)} />
       <meta property={"og:image:height"} content={String(cardImage.height)} />
-      <meta
-        property={"og:url"}
-        content={`https://${NEXT_PUBLIC_VERCEL_URL}/${router.pathname}`}
-      />
+      <meta property={"og:url"} content={toPublicUrl(router.pathname)} />
       <meta property={"og:description"} content={pageDescription} />
       <meta property={"og:locale"} content={"ja_JP"} />
       <meta property={"og:site_name"} content={NEXT_PUBLIC_SITE_TITLE} />

--- a/src/components/feature/metaCitation/MetaCitation.tsx
+++ b/src/components/feature/metaCitation/MetaCitation.tsx
@@ -33,7 +33,9 @@ export const MetaCitation: FC<MetaCitationProps> = ({ paper }) => {
       {paper.publication.firstPage && (
         <meta name="firstpage" content={paper.publication.firstPage} />
       )}
-      <meta name="lastpage" content={`${paper.publication.lastPage}`} />
+      {paper.publication.lastPage && (
+        <meta name="lastpage" content={paper.publication.lastPage} />
+      )}
       <meta
         name={"citation_abstract_html_url"}
         content={toPublicUrl(ROUTES.RESEARCH_DETAIL(paper.slug))}

--- a/src/components/feature/metaCitation/MetaCitation.tsx
+++ b/src/components/feature/metaCitation/MetaCitation.tsx
@@ -1,0 +1,72 @@
+import Head from "next/head";
+import { FC } from "react";
+
+import { dateToYYYYMMDD } from "@/lib/formatDate";
+import { ROUTES, toPublicUrl } from "@/lib/routes";
+import { AuthorModel, PaperModel } from "@/models/models";
+
+export type MetaCitationProps = {
+  paper: PaperModel;
+};
+
+export const MetaCitation: FC<MetaCitationProps> = ({ paper }) => {
+  const publishDate = new Date(paper.publishDateStr);
+  const date = dateToYYYYMMDD(publishDate, "/");
+  const lang = {
+    english: "en",
+    japanese: "ja",
+  }[paper.language];
+
+  return (
+    <Head>
+      <meta name="citation_title" content={paper.title} />
+      {paper.authors.map((author) => (
+        <meta
+          name="citation_author"
+          key={author.id}
+          content={getAuthorMetaName(paper.language, author)}
+        />
+      ))}
+      <meta name={"citation_date"} content={date} />
+      <meta name="citation_publication_date" content={date} />
+      <meta name="citation_year" content={`${publishDate.getFullYear()}`} />
+      {paper.publication.firstPage && (
+        <meta name="firstpage" content={paper.publication.firstPage} />
+      )}
+      <meta name="lastpage" content={`${paper.publication.lastPage}`} />
+      <meta
+        name={"citation_abstract_html_url"}
+        content={toPublicUrl(ROUTES.RESEARCH_DETAIL(paper.slug))}
+      />
+      <meta name="citation_language" content={lang} />
+      <meta name="citation_journal_title" content={paper.journalTitle} />
+      {paper.publication.volume && (
+        <meta name="citation_volume" content={paper.publication.volume} />
+      )}
+      {paper.publication.issue && (
+        <meta name="citation_issue" content={paper.publication.issue} />
+      )}
+      {paper.publication.publisher && (
+        <meta name="citation_publisher" content={paper.publication.publisher} />
+      )}
+      {paper.pdfUrl && (
+        <meta name="citation_pdf_url" content={toPublicUrl(paper.pdfUrl)} />
+      )}
+      <meta name="citation_keywords" content={paper.keywords.join("; ")} />
+    </Head>
+  );
+};
+
+const getAuthorMetaName = (
+  lang: PaperModel["language"],
+  author: AuthorModel
+) => {
+  switch (lang) {
+    case "japanese":
+      return `${author.familyName.ja}, ${author.givenName.ja}`;
+    case "english":
+      return `${author.givenName.en} ${author.familyName.en}`;
+    default:
+      throw new Error("Invalid language");
+  }
+};

--- a/src/components/feature/metaCitation/index.ts
+++ b/src/components/feature/metaCitation/index.ts
@@ -1,0 +1,2 @@
+export { MetaCitation } from "./MetaCitation";
+export type { MetaCitationProps } from "./MetaCitation";

--- a/src/components/page/researchDetail/ResearchDetail.tsx
+++ b/src/components/page/researchDetail/ResearchDetail.tsx
@@ -1,5 +1,5 @@
 import classNames from "classnames";
-import { FC, useCallback, useEffect, useRef, useState } from "react";
+import { FC, useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 import { BeautifulBreak } from "@/components/feature/beautifulBreak";
 import { WrapLink } from "@/components/feature/wrapLink";
@@ -52,6 +52,13 @@ export const ResearchDetail: FC<PaperModel> = ({
   }, [showCite]);
 
   const publishDateYYYYMMDD = dateToYYYYMMDD(new Date(publishDateStr));
+
+  const pages = useMemo(() => {
+    if (!publication.firstPage || !publication.lastPage) return undefined;
+    if (publication.firstPage === publication.lastPage)
+      return publication.firstPage;
+    return `${publication.firstPage} - ${publication.lastPage}`;
+  }, [publication.firstPage, publication.lastPage]);
 
   return (
     <div>
@@ -129,9 +136,7 @@ export const ResearchDetail: FC<PaperModel> = ({
                 {publication.issue && (
                   <InfoItem label={"Number:"}>{publication.issue}</InfoItem>
                 )}
-                {publication.pages && (
-                  <InfoItem label={"Pages:"}>{publication.pages}</InfoItem>
-                )}
+                {pages && <InfoItem label={"Pages:"}>{pages}</InfoItem>}
               </div>
               <InfoItem label={"Source URL:"}>
                 <WrapLink href={publication.url} className={"break-all"}>

--- a/src/lib/formatDate.ts
+++ b/src/lib/formatDate.ts
@@ -1,7 +1,7 @@
-export const dateToYYYYMMDD = (date: Date): string => {
+export const dateToYYYYMMDD = (date: Date, separator = "-"): string => {
   const year = date.getFullYear();
   const month = (date.getMonth() + 1).toString().padStart(2, "0");
   const day = date.getDate().toString().padStart(2, "0");
 
-  return `${year}-${month}-${day}`;
+  return [year, month, day].join(separator);
 };

--- a/src/lib/routes.ts
+++ b/src/lib/routes.ts
@@ -16,3 +16,7 @@ export const ROUTES = {
   API_ASSET: (id: string, filename?: string) =>
     `/api/asset/${id}${filename ? `?name=${filename}` : ""}`,
 } as const;
+
+export const toPublicUrl = (relativePath: string) => {
+  return `https://${process.env.NEXT_PUBLIC_BASE_URL}${relativePath}`;
+};

--- a/src/lib/routes.ts
+++ b/src/lib/routes.ts
@@ -15,6 +15,7 @@ export const ROUTES = {
   ABOUT: "/about",
   PRIVACY_POLICY: "/privacy-policy",
   COPYRIGHT: "/copyright",
+  API_ASSET: (id: string) => `/api/asset/${id}`,
 } as const;
 
 export const toPublicUrl = (relativePath: string) => {

--- a/src/lib/routes.ts
+++ b/src/lib/routes.ts
@@ -6,6 +6,8 @@ export const ROUTES = {
   MEMBER_DETAIL: (slug: string) => `/members/${slug}`,
   RESEARCHES: "/researches",
   RESEARCH_DETAIL: (slug: string) => `/researches/${slug}`,
+  RESEARCH_DETAIL_PDF: (slug: string, fileName: string) =>
+    `/researches/${slug}/assets/${fileName}.pdf`,
   RESEARCH_AUTHOR_FILTERED: (authorName: string) =>
     `/researches?filter=author:${authorName}`,
   PROJECTS: "/projects",
@@ -13,8 +15,6 @@ export const ROUTES = {
   ABOUT: "/about",
   PRIVACY_POLICY: "/privacy-policy",
   COPYRIGHT: "/copyright",
-  API_ASSET: (id: string, filename?: string) =>
-    `/api/asset/${id}${filename ? `?name=${filename}` : ""}`,
 } as const;
 
 export const toPublicUrl = (relativePath: string) => {

--- a/src/lib/routes.ts
+++ b/src/lib/routes.ts
@@ -1,3 +1,5 @@
+import { NEXT_PUBLIC_VERCEL_URL } from "@/lib/publicEnvironments";
+
 export const ROUTES = {
   HOME: "/",
   NEWS: "/news",
@@ -19,5 +21,5 @@ export const ROUTES = {
 } as const;
 
 export const toPublicUrl = (relativePath: string) => {
-  return `https://${process.env.NEXT_PUBLIC_BASE_URL}${relativePath}`;
+  return `https://${NEXT_PUBLIC_VERCEL_URL}${relativePath}`;
 };

--- a/src/models/mockData.ts
+++ b/src/models/mockData.ts
@@ -104,10 +104,8 @@ export const paperModelMock = (faker: Faker): PaperModel => {
 
       volume: `${faker.number.int({ min: 1, max: 100 })}`,
       issue: `${faker.number.int({ min: 1, max: 100 })}`,
-      pages: `${faker.number.int({ min: 1, max: 100 })} - ${faker.number.int({
-        min: 1,
-        max: 100,
-      })}`,
+      firstPage: `${faker.number.int({ min: 1, max: 100 })}`,
+      lastPage: `${faker.number.int({ min: 1, max: 100 })}`,
       publisher: faker.company.name(),
       copyrightHolder: faker.company.name(),
       quotation: "quotation",

--- a/src/models/models.ts
+++ b/src/models/models.ts
@@ -68,7 +68,8 @@ export type PaperModel = PartialPaperModel & {
     url: string | null;
     volume: string | null;
     issue: string | null;
-    pages: string | null;
+    firstPage: string | null;
+    lastPage: string | null;
     publisher: string | null;
     copyrightHolder: string | null;
     quotation: string;

--- a/src/models/transformer/transformPaper.ts
+++ b/src/models/transformer/transformPaper.ts
@@ -109,10 +109,10 @@ export const transformPaperModel = (
       }
     }
 
-    if (slidePdf && slidePdf.fields.file?.url) {
+    if (slidePdf && slidePdf.sys.id) {
       return {
         type: "slide",
-        slidePdfUrl: slidePdf.fields.file?.url,
+        slidePdfUrl: ROUTES.API_ASSET(slidePdf.sys.id),
       } satisfies PaperHeroModel;
     }
 

--- a/src/models/transformer/transformPaper.ts
+++ b/src/models/transformer/transformPaper.ts
@@ -78,7 +78,6 @@ export const transformPaperModel = (
     thumbnail,
   } = paper.fields;
 
-  const pages = `${firstPage} - ${lastPage}`;
   const quotation = ipsjQuotation(paper);
 
   const hero: PaperHeroModel | null = (() => {
@@ -147,7 +146,8 @@ export const transformPaperModel = (
       url: publishUrl ?? null,
       volume: volume ?? null,
       issue: issue ?? null,
-      pages: pages,
+      firstPage: firstPage ?? null,
+      lastPage: lastPage ?? null,
       publisher: publisher ?? null,
       copyrightHolder: copyrightHolder ?? null,
       quotation: quotation,

--- a/src/models/transformer/transformPaper.ts
+++ b/src/models/transformer/transformPaper.ts
@@ -63,6 +63,7 @@ export const transformPartialPaperModel = (
 export const transformPaperModel = (
   paper: Entry<TypePaperSkeleton, "WITHOUT_UNRESOLVABLE_LINKS", string>
 ): PaperModel => {
+  const entryId = paper.sys.id;
   const {
     publisher,
     copyrightHolder,
@@ -155,7 +156,7 @@ export const transformPaperModel = (
     },
     pdfUrl:
       pdfAssetId !== undefined
-        ? ROUTES.API_ASSET(pdfAssetId, paper.fields.title)
+        ? ROUTES.RESEARCH_DETAIL_PDF(entryId, paper.fields.title)
         : null,
     hero: hero,
   };

--- a/src/pages/api/asset-paper/[paperId].ts
+++ b/src/pages/api/asset-paper/[paperId].ts
@@ -1,0 +1,64 @@
+import { NextRequest, NextResponse } from "next/server";
+
+import {
+  CONTENTFUL_DELIVERY_TOKEN,
+  CONTENTFUL_SPACE_ID,
+} from "@/lib/environments";
+
+export const config = {
+  runtime: "edge",
+};
+
+// serverless functionはレスポンスのペイロードが上限が4MBなので、上限がより多いedge functionを使う
+
+const handler = async (req: NextRequest) => {
+  const url = new URL(req.nextUrl);
+  const paperId = url.searchParams.get("paperId");
+
+  if (!paperId) {
+    return NextResponse.json({ message: "id is required" }, { status: 400 });
+  }
+
+  //paperモデルをfetch
+  const paperApiUrl = `https://cdn.contentful.com/spaces/${CONTENTFUL_SPACE_ID}/environments/master/entries/${paperId}?access_token=${CONTENTFUL_DELIVERY_TOKEN}`;
+  const paperApiRes = await fetch(paperApiUrl);
+
+  if (!paperApiRes.ok) {
+    return NextResponse.json(
+      { message: "asset not found" },
+      { status: 400 }
+    );
+  }
+
+  const paperApiResJson = await paperApiRes.json();
+  const assetId = paperApiResJson.fields.pdf.sys.id;
+
+  //paperのpdfフィールドに紐付くassetをfetch
+  const assetApiUrl = `https://cdn.contentful.com/spaces/${CONTENTFUL_SPACE_ID}/environments/master/assets/${assetId}?access_token=${CONTENTFUL_DELIVERY_TOKEN}`;
+  const assetApiRes = await fetch(assetApiUrl);
+
+  if (!assetApiRes.ok) {
+    return NextResponse.json({ message: "asset not found" }, { status: 400 });
+  }
+
+  const assetApiResJson = await assetApiRes.json();
+  const assetUrl = assetApiResJson.fields.file?.url;
+
+  const assetType = assetApiResJson.fields.file?.contentType;
+
+  if (!assetUrl) {
+    return NextResponse.json({ message: "asset not found" }, { status: 400 });
+  }
+
+  const asset = await fetch(`https:${assetUrl}`);
+
+  return new NextResponse(asset.body, {
+    status: 200,
+    headers: {
+      "Cache-Control": "s-maxage=604800",
+      "Content-type": assetType,
+    },
+  });
+};
+
+export default handler;

--- a/src/pages/researches/[slug]/index.tsx
+++ b/src/pages/researches/[slug]/index.tsx
@@ -1,6 +1,7 @@
 import { GetStaticProps } from "next";
 
 import { Meta } from "@/components/feature/meta";
+import { MetaCitation } from "@/components/feature/metaCitation";
 import { Layout } from "@/components/page/layout";
 import { ResearchDetail } from "@/components/page/researchDetail";
 import { fetchPaper, fetchPartialPaperList } from "@/lib/cms/fetchPaper";
@@ -18,6 +19,7 @@ const ResearchPage: NextPageWithLayout<Props> = ({ ...props }) => {
         cardImage={props.thumbnailImg}
         pageKeywords={props.keywords}
       />
+      <MetaCitation paper={props} />
       <ResearchDetail {...props} />
     </>
   );


### PR DESCRIPTION
- resolves #112 
- PDFの配信パスを変更
  - Google Scholar側の仕様で、PDFは論文詳細ページとサブディレクトリが同じでなければならない
  - https://scholar.google.com/intl/en/scholar/inclusion.html#indexing