### PR TITLE
画面幅が狭いときに研究ページのレイアウトが崩れるのを修正

### DIFF
--- a/src/components/ui/paginationNav/PaginationNav.tsx
+++ b/src/components/ui/paginationNav/PaginationNav.tsx
@@ -68,7 +68,7 @@ export const PaginationNav: FC<PaginationNavProps> = ({
   return (
     <nav className={classNames("flex justify-center")} {...props}>
       <ul className="flex">
-        <li className={"w-12 md:w-24"}>
+        <li className={"w-10 sm:w-12 md:w-24"}>
           <PaginationNavButton
             href={prevPageHref}
             onClick={prevPageClick}
@@ -131,7 +131,7 @@ export const PaginationNav: FC<PaginationNavProps> = ({
             </li>
           );
         })}
-        <li className={"w-12 md:w-24"}>
+        <li className={"w-10 sm:w-12 md:w-24"}>
           <PaginationNavButton
             href={nextPageHref}
             onClick={nextPageClick}

--- a/src/components/ui/researchFilterItem/ResearchFilterItem.tsx
+++ b/src/components/ui/researchFilterItem/ResearchFilterItem.tsx
@@ -37,26 +37,28 @@ export const ResearchFilterItem = <T extends string>({
   );
 
   return (
-    <div className={"grid h-full w-full grid-cols-[1fr_max-content]"}>
-      <div className={"grid grid-cols-[max-content_1fr]"}>
-        <select
-          value={type}
-          onChange={handleSelectChange}
-          className={"rounded-l-lg border border-gray-300 p-1 text-gray-800"}
-        >
-          {typeOptions.map(({ value, label }) => (
-            <option key={value} value={value}>
-              {label}
-            </option>
-          ))}
-        </select>
-        <input
-          type="text"
-          value={text}
-          onChange={handleTextChange}
-          className={"rounded-r-lg border border-gray-300 p-1 text-gray-800"}
-        />
-      </div>
+    <div
+      className={
+        "grid h-full w-full grid-cols-[minmax(4rem,1fr)_minmax(0,3fr)_max-content]"
+      }
+    >
+      <select
+        value={type}
+        onChange={handleSelectChange}
+        className={"rounded-l-lg border border-gray-300 p-1 text-gray-800"}
+      >
+        {typeOptions.map(({ value, label }) => (
+          <option key={value} value={value}>
+            {label}
+          </option>
+        ))}
+      </select>
+      <input
+        type="text"
+        value={text}
+        onChange={handleTextChange}
+        className={"rounded-r-lg border border-gray-300 p-1 text-gray-800"}
+      />
       <div className={"flex items-center justify-center p-1"}>
         <button
           type={"button"}


### PR DESCRIPTION
<img width="484" alt="スクリーンショット 2023-08-18 15 10 27" src="https://github.com/MiyashitaLab/miyashita-lab-website-2023/assets/37701077/eb78ec23-29f8-48c1-8a22-c9f40b79e0a7">
