### PR TITLE
Markdown中の画像サイズを柔軟に

### DIFF
--- a/src/components/feature/wrapImage/WrapImage.tsx
+++ b/src/components/feature/wrapImage/WrapImage.tsx
@@ -39,7 +39,6 @@ export type WrapImageInlineProps = CMSImage & {
   alt: string;
   priority?: boolean;
   sizes: SizeSet;
-  sizesFlow?: "height" | "width";
 };
 
 /**
@@ -95,7 +94,7 @@ export const WrapImageSized: FC<WrapImageSizedProps> = ({
 
 /**
  * next/imageを使って画像を表示するコンポーネント
- * 画像サイズを親サイズに合わせたい場合はこちらを使う
+ * サイズが親側で決まっている場合はこれをつかう
  */
 export const WrapImageFill: FC<WrapImageFillProps> = ({
   src,
@@ -119,24 +118,27 @@ export const WrapImageFill: FC<WrapImageFillProps> = ({
   );
 };
 
+/**
+ * next/imageを使って画像を表示するコンポーネント
+ * Markdownの中に入れるときに使う
+ */
 export const WrapImageInline: FC<WrapImageInlineProps> = ({
   src,
   alt,
   priority,
   sizes,
-  sizesFlow = "width",
 }) => {
   const sizesSet = constructSizesSrcSet(sizes);
 
   return (
-    <span className={"relative flex h-full w-full items-center justify-center"}>
+    <span className={"relative h-full"}>
       <Image
         src={src}
         alt={alt}
         priority={priority}
         fill
         sizes={sizesSet}
-        className={"object-contain"}
+        className={"!relative max-h-96 object-contain"}
       />
     </span>
   );

--- a/src/components/ui/markdownContent/MarkdownContent.tsx
+++ b/src/components/ui/markdownContent/MarkdownContent.tsx
@@ -4,7 +4,10 @@ import ReactMarkdown from "react-markdown";
 import rehypeRaw from "rehype-raw";
 import remarkGfm from "remark-gfm";
 
-import { WrapImageInline } from "@/components/feature/wrapImage/WrapImage";
+import {
+  WrapImageInline,
+  WrapImageSized,
+} from "@/components/feature/wrapImage/WrapImage";
 import { WrapLink } from "@/components/feature/wrapLink";
 import { wrapImageUrl } from "@/models/transformer/transformCMSImage";
 
@@ -155,21 +158,35 @@ export const MarkdownContent: FC<MarkdownContentProps> = ({
         hr: ({ children }) => (
           <hr className={"my-4 border-gray-300"}>{children}</hr>
         ),
-        img: ({ src, alt = "" }) => (
-          <span
-            className={"peer relative my-2 block h-60 max-w-full"}
-            data-label={"img-container"}
-          >
+        img: ({ src, alt = "", width, height }) => {
+          // imgタグべた書きでwidthとheightを明記した場合
+          const sizeSpecified =
+            typeof width === "number" && typeof height === "number";
+
+          const imgElem = sizeSpecified ? (
+            <WrapImageSized
+              src={wrapImageUrl(src!)}
+              alt={alt}
+              width={width}
+              height={height}
+            />
+          ) : (
             <WrapImageInline
               src={wrapImageUrl(src!)}
               alt={alt}
               sizes={{
-                base: "15rem", //h-60
+                sm: "100vw",
+                base: "640px", //screen-sm
               }}
-              sizesFlow={"height"}
             />
-          </span>
-        ),
+          );
+
+          return (
+            <span className={"w-full"}>
+              <span className={"mx-auto block max-w-screen-sm"}>{imgElem}</span>
+            </span>
+          );
+        },
         iframe: ({ node, ...props }) => {
           return (
             <div className={"flex justify-center"}>

--- a/src/components/ui/markdownContent/MarkdownContent.tsx
+++ b/src/components/ui/markdownContent/MarkdownContent.tsx
@@ -163,13 +163,17 @@ export const MarkdownContent: FC<MarkdownContentProps> = ({
           const sizeSpecified =
             typeof width === "number" && typeof height === "number";
 
+          // WrapImageInlineはobject-containによって中央寄せされる
+          // WrapImageSizedにはついていないのでflexで中央寄せする
           const imgElem = sizeSpecified ? (
-            <WrapImageSized
-              src={wrapImageUrl(src!)}
-              alt={alt}
-              width={width}
-              height={height}
-            />
+            <div className={"flex items-center justify-center"}>
+              <WrapImageSized
+                src={wrapImageUrl(src!)}
+                alt={alt}
+                width={width}
+                height={height}
+              />
+            </div>
           ) : (
             <WrapImageInline
               src={wrapImageUrl(src!)}
@@ -183,7 +187,7 @@ export const MarkdownContent: FC<MarkdownContentProps> = ({
 
           return (
             <span className={"w-full"}>
-              <span className={"mx-auto block max-w-screen-sm"}>{imgElem}</span>
+              <span className={"mx-auto max-w-screen-sm"}>{imgElem}</span>
             </span>
           );
         },


### PR DESCRIPTION
Markdown中の画像表示の仕様を以下の様に変更した

### サイズを指定しない場合
- `![altaltalt](srcsrcsrc)`
- 以下の上限内でできるだけ大きく表示される
  - width: 640 px
  - height: 384 px
- 元の画像サイズは考慮されない

### サイズを指定する場合
- `<img src="srcsrcsrc" alt="altaltalt" width="800px" height="600px">`
- widthとheightは必ず両方指定する必要がある
- ただし、実際のレンダリングサイズは元画像のアスペクト比と指定したwidthの値によって決定される
